### PR TITLE
correct syntax line 33 in main/self_balancing.c

### DIFF
--- a/8_self_balancing/main/self_balancing.c
+++ b/8_self_balancing/main/self_balancing.c
@@ -30,7 +30,7 @@ void calculate_motor_command(const float pitch_error, float *motor_cmd)
 
 	static float prev_pitch_error = 0.0f;
 	static float pitch_error_cumulative = 0.0f;
-	float pitch_error_difference = 0.0f, 
+	float pitch_error_difference = 0.0f; 
 
 	float pitch_correction = 0.0f, absolute_pitch_correction = 0.0f;
 	float pitch_rate = 0.0f, pitch_area = 0.0f;


### PR DESCRIPTION
Corrected colon in [line no 33](https://github.com/SRA-VJTI/Wall-E_v2.2-beta/blob/f87eb127c867c17caf17f6e8baa8f4773d5f9412/8_self_balancing/main/self_balancing.c#L33) in main/self_balancing.c, now no compilation error